### PR TITLE
Fix udecode assert with type coersion

### DIFF
--- a/opt/n_unicode.c
+++ b/opt/n_unicode.c
@@ -326,7 +326,7 @@ char *uungetch(int c, cbuf_t *pcb, char *next) {
     char *p;
 #endif    
     assert(pcb->buf <= prev);
-    assert((p = prev, udecode_check(&p)) == c && p == next); 
+    assert((p = prev, udecode_check((const char **)&p)) == c && p == next); 
     return prev;
   } else {
     char *prev = next - 1;


### PR DESCRIPTION
Compiling like this:

```
make CFLAGS="-O3 -DNAN_BOXING -DOPT_UNICODE -DOPT_ENHTTY" version is 0.7.1
prefix is set to /usr
use-unicode is set to 1
use-enhanced-tty is set to 1
X86_64 architecture is detected
gcc -O3 -DNAN_BOXING -DOPT_UNICODE -DOPT_ENHTTY -c -o s.o s.c gcc -O3 -DNAN_BOXING -DOPT_UNICODE -DOPT_ENHTTY -c -o k.o k.c gcc -O3 -DNAN_BOXING -DOPT_UNICODE -DOPT_ENHTTY -c -o i.o i.c gcc -O3 -DNAN_BOXING -DOPT_UNICODE -DOPT_ENHTTY -c -o n.o n.c In file included from n.h:17,
                 from n.c:4:
opt/n_unicode.c: In function ‘uungetch’:
opt/n_unicode.c:329:37: error: passing argument 1 of ‘udecode_check’ from incompatible pointer type [-Wincompatible-pointer-types]
  329 |     assert((p = prev, udecode_check(&p)) == c && p == next);
      |                                     ^~
      |                                     |
      |                                     char **
In file included from n.c:310:
opt/n_unicode.c:7:32: note: expected ‘const char **’ but argument is of type ‘char **’
    7 | int udecode_check(const char **sp)
      |                   ~~~~~~~~~~~~~^~
```