### PR TITLE
SRFI-253: Fix lambda-checked return types for corner cases

### DIFF
--- a/lib/srfi/253.sld
+++ b/lib/srfi/253.sld
@@ -98,11 +98,21 @@
           name body
           (args ... . last) (checks ...)))))
     (define-syntax lambda-checked
-      (syntax-rules ()
+      (syntax-rules (=>)
+        ;; Empty args with return type checking
+        ((_ () => (returns ...) body ...)
+         (lambda ()
+           (values-checked (returns ...) (begin body ...))))
+        ;; No need to parse as there are no args
         ((_ () body ...)
          (lambda () body ...))
+        ;; Regular (positional ... [. rest]) arglist
         ((_ (arg . args) body ...)
          (%lambda-checked lambda-checked (body ...) () () arg . args))
+        ;; arg->list lambda, but with return checking
+        ((_ arg => (returns ...) body ...)
+         (lambda arg
+           (values-checked (returns ...) (begin body ...))))
         ;; Case of arg->list lambda, no-op.
         ((_ arg body ...)
          (lambda arg body ...))))


### PR DESCRIPTION
Previously forms like `(lambda () => (return ...) ...)` didn’t work.