### PR TITLE
Make i.h inclusion more flexible

### DIFF
--- a/i.c
+++ b/i.c
@@ -4824,9 +4824,12 @@ define_instruction(libdir) {
   gonexti();
 }
 
-#define VM_GEN_DEFGLOBAL
+#define declare_instruction(name, enc, etyp, igname, arity, lcode) \
+  declare_instruction_global(name)
+#define declare_integrable(name, enc, etyp, igname, arity, lcode)
 #include "i.h"
-#undef  VM_GEN_DEFGLOBAL
+#undef declare_instruction
+#undef declare_integrable
 
 /* integrables table */
 struct intgtab_entry { int sym; char *igname; int igtype; char *enc; char *lcode; };
@@ -4834,9 +4837,13 @@ struct intgtab_entry { int sym; char *igname; int igtype; char *enc; char *lcode
    { 0, igname, igtype, enc, lcode },
 
 static struct intgtab_entry intgtab[] = {
-#define VM_GEN_INTGTABLE
+#define declare_instruction(name, enc, etyp, igname, arity, lcode) \
+  declare_intgtable_entry(enc, igname, arity, lcode)
+#define declare_integrable(name, enc, etyp, igname, arity, lcode) \
+  declare_intgtable_entry(enc, igname, arity, lcode)
 #include "i.h"
-#undef  VM_GEN_INTGTABLE
+#undef declare_instruction
+#undef declare_integrable
 };
 
 static int intgtab_sorted = 0;
@@ -5215,12 +5222,12 @@ static obj *rds_stox(obj *r, obj *sp, obj *hp)
 }
 
 static struct { obj *pg; const char *enc; int etyp; } enctab[] = {
-#define VM_GEN_ENCTABLE
-#define declare_enctable_entry(name, enc, etyp) \
- { &glue(cx_ins_2D, name), enc, etyp },
+#define declare_instruction(name, enc, etyp, igname, arity, lcode) \
+	{ &glue(cx_ins_2D, name), enc, etyp },
+#define declare_integrable(name, enc, etyp, igname, arity, lcode)
 #include "i.h"
-#undef declare_enctable_entry
-#undef VM_GEN_ENCTABLE
+#undef declare_instruction
+#undef declare_integrable
  { NULL, NULL, 0 }
 };
 

--- a/i.h
+++ b/i.h
@@ -10,23 +10,13 @@
 #define INLINED ""
 #endif
 
-#if defined(VM_GEN_DEFGLOBAL)
+/* Default case of non-overridden
+ * declare_instruction / declare_integrable.
+ * One ifndef is enough, because these two are always used in tandem. */
+#ifndef declare_instruction
 #define declare_instruction(name, enc, etyp, igname, arity, lcode) \
-  declare_instruction_global(name)
-#define declare_integrable(name, enc, etyp, igname, arity, lcode) 
-#elif defined(VM_GEN_ENCTABLE)
-#define declare_instruction(name, enc, etyp, igname, arity, lcode) \
-  declare_enctable_entry(name, enc, etyp)
-#define declare_integrable(name, enc, etyp, igname, arity, lcode) 
-#elif defined(VM_GEN_INTGTABLE)
-#define declare_instruction(name, enc, etyp, igname, arity, lcode) \
-  declare_intgtable_entry(enc, igname, arity, lcode)
-#define declare_integrable(name, enc, etyp, igname, arity, lcode) \
-  declare_intgtable_entry(enc, igname, arity, lcode)
-#else /* regular include */
-#define declare_instruction(name, enc, etyp, igname, arity, lcode) \
-  extern obj glue(cx_ins_2D, name); 
-#define declare_integrable(name, enc, etyp, igname, arity, lcode) 
+  extern obj glue(cx_ins_2D, name);
+#define declare_integrable(name, enc, etyp, igname, arity, lcode)
 extern obj vmcases[]; /* vm host */
 #endif
 


### PR DESCRIPTION
The conventional X-macro pattern relies on macros being used in the included file (`i.h`), with these macros being defined right before its use. In Skint, this pattern was unnecessarily complicated, with additional flag macros defined for dispatching, and then used in `i.h` instead of simply using macros and defining them right before including `i.h`. This PR fixes the pattern and simplifies the code slightly.

@dermagen how does it look?