### PR TITLE
Disassembler draft

### DIFF
--- a/i.c
+++ b/i.c
@@ -4334,6 +4334,14 @@ define_instruction(vmcloco) {
   gonexti();
 }
 
+const char *find_instruction_name(long obj);
+
+define_instruction(cloinm) {
+  const char *name = find_instruction_name(ac);
+  ac = name ? string_obj(newsdata((char*)name)) : bool_obj(0);
+  gonexti();
+}
+
 define_instruction(hshim) {
   uint64_t v = (uint64_t)ac, base = 0; obj b = spop(); 
   if (b) { ckk(b); base = get_fixnum(b); } 
@@ -5232,15 +5240,24 @@ static obj *rds_stox(obj *r, obj *sp, obj *hp)
   return hp;
 }
 
-static struct { obj *pg; const char *enc; int etyp; } enctab[] = {
+static struct { obj *pg; const char *name; const char *enc; int etyp; } enctab[] = {
 #define declare_instruction(name, enc, etyp, igname, arity, lcode) \
-	{ &glue(cx_ins_2D, name), enc, etyp },
+	{ &glue(cx_ins_2D, name), #name, enc, etyp },
 #define declare_integrable(name, enc, etyp, igname, arity, lcode)
 #include "i.h"
 #undef declare_instruction
 #undef declare_integrable
- { NULL, NULL, 0 }
+ { NULL, NULL, NULL, 0 }
 };
+
+const char *find_instruction_name(long inst) {
+  int i;
+  for (i = 0; enctab[i].pg != NULL; ++i)
+    if (enctab[i].enc != NULL)
+      if (*enctab[i].pg == inst)
+        return enctab[i].name;
+  return NULL;
+}
 
 struct emtrans { int c; struct embranch *pbr; struct emtrans *ptr; };
 struct embranch { obj g; int etyp; struct emtrans *ptr; };

--- a/i.c
+++ b/i.c
@@ -4824,9 +4824,12 @@ define_instruction(libdir) {
   gonexti();
 }
 
-#define VM_GEN_DEFGLOBAL
+#define declare_instruction(name, enc, etyp, igname, arity, lcode) \
+  declare_instruction_global(name)
+#define declare_integrable(name, enc, etyp, igname, arity, lcode)
 #include "i.h"
-#undef  VM_GEN_DEFGLOBAL
+#undef declare_instruction
+#undef declare_integrable
 
 /* integrables table */
 struct intgtab_entry { int sym; char *igname; int igtype; char *enc; char *lcode; };
@@ -4834,9 +4837,13 @@ struct intgtab_entry { int sym; char *igname; int igtype; char *enc; char *lcode
    { 0, igname, igtype, enc, lcode },
 
 static struct intgtab_entry intgtab[] = {
-#define VM_GEN_INTGTABLE
+#define declare_instruction(name, enc, etyp, igname, arity, lcode) \
+  declare_intgtable_entry(enc, igname, arity, lcode)
+#define declare_integrable(name, enc, etyp, igname, arity, lcode) \
+  declare_intgtable_entry(enc, igname, arity, lcode)
 #include "i.h"
-#undef  VM_GEN_INTGTABLE
+#undef declare_instruction
+#undef declare_integrable
 };
 
 static int intgtab_sorted = 0;
@@ -5215,12 +5222,12 @@ static obj *rds_stox(obj *r, obj *sp, obj *hp)
 }
 
 static struct { obj *pg; const char *enc; int etyp; } enctab[] = {
-#define VM_GEN_ENCTABLE
-#define declare_enctable_entry(name, enc, etyp) \
- { &glue(cx_ins_2D, name), enc, etyp },
+#define declare_instruction(name, enc, etyp, igname, arity, lcode) \
+	{ &glue(cx_ins_2D, name), enc, etyp },
+#define declare_integrable(name, enc, etyp, igname, arity, lcode)
 #include "i.h"
-#undef declare_enctable_entry
-#undef VM_GEN_ENCTABLE
+#undef declare_instruction
+#undef declare_integrable
  { NULL, NULL, 0 }
 };
 

--- a/i.c
+++ b/i.c
@@ -4359,6 +4359,11 @@ define_instruction(hshim) {
   gonexti();
 }
 
+define_instruction(addr) {
+  uint64_t v = (uint64_t)ac;
+  ac = fixnum_obj(v);
+  gonexti();
+}
 
 define_instruction(rdsx) {
   cks(ac); 

--- a/i.c
+++ b/i.c
@@ -4323,6 +4323,17 @@ define_instruction(vmclo) {
   gonexti();
 }
 
+define_instruction(vmcloco) {
+  int n; obj cs; ckx(ac); ckk(sref(0));
+  n = get_fixnum(spop());
+  if (n > vmclolen(ac))
+    cs = 0;
+  else
+    cs = vmcloref(ac, n);
+  ac = cs ? cs : bool_obj(0);
+  gonexti();
+}
+
 define_instruction(hshim) {
   uint64_t v = (uint64_t)ac, base = 0; obj b = spop(); 
   if (b) { ckk(b); base = get_fixnum(b); } 

--- a/i.h
+++ b/i.h
@@ -666,7 +666,7 @@ declare_instruction(igty,       "U6",           0,  "integrable-type",          
 declare_instruction(iggl,       "U7",           0,  "integrable-global",        '1', AUTOGL)
 declare_instruction(igco,       "U8",           0,  "integrable-code",          '2', AUTOGL)
 declare_instruction(vmclo,      "U9",           1,  "closure",                  '#', INLINED)
-declare_instruction(vmcloco,    "Ug",           0,  "closure-code",             '2', AUTOGL)
+declare_instruction(vmcloco,    "Ug",           0,  "%closure-code-ref",        '2', AUTOGL)
 declare_instruction(cloinm,     "Ui",           0,  "%procedure->inst-name",    '1', INLINED)
 
 /* inlined integrables (no custom instructions) */               

--- a/i.h
+++ b/i.h
@@ -666,6 +666,7 @@ declare_instruction(iggl,       "U7",           0,  "integrable-global",        
 declare_instruction(igco,       "U8",           0,  "integrable-code",          '2', AUTOGL)
 declare_instruction(vmclo,      "U9",           1,  "closure",                  '#', INLINED)
 declare_instruction(vmcloco,    "Ug",           0,  "closure-code",             '2', AUTOGL)
+declare_instruction(cloinm,     "Ui",           0,  "%procedure->inst-name",    '1', INLINED)
 
 /* inlined integrables (no custom instructions) */               
 declare_integrable(NULL,        "q",            0,  "boolean=?",                'c', AUTOGL)

--- a/i.h
+++ b/i.h
@@ -667,7 +667,7 @@ declare_instruction(iggl,       "U7",           0,  "integrable-global",        
 declare_instruction(igco,       "U8",           0,  "integrable-code",          '2', AUTOGL)
 declare_instruction(vmclo,      "U9",           1,  "closure",                  '#', INLINED)
 declare_instruction(vmcloco,    "Ug",           0,  "%closure-code-ref",        '2', AUTOGL)
-declare_instruction(cloinm,     "Ui",           0,  "%procedure->inst-name",    '1', INLINED)
+declare_instruction(cloinm,     "Ui",           0,  "%procedure->inst-name",    '1', AUTOGL)
 
 /* inlined integrables (no custom instructions) */               
 declare_integrable(NULL,        "q",            0,  "boolean=?",                'c', AUTOGL)

--- a/i.h
+++ b/i.h
@@ -10,23 +10,13 @@
 #define INLINED ""
 #endif
 
-#if defined(VM_GEN_DEFGLOBAL)
+/* Default case of non-overridden
+ * declare_instruction / declare_integrable.
+ * One ifndef is enough, because these two are always used in tandem. */
+#ifndef declare_instruction
 #define declare_instruction(name, enc, etyp, igname, arity, lcode) \
-  declare_instruction_global(name)
-#define declare_integrable(name, enc, etyp, igname, arity, lcode) 
-#elif defined(VM_GEN_ENCTABLE)
-#define declare_instruction(name, enc, etyp, igname, arity, lcode) \
-  declare_enctable_entry(name, enc, etyp)
-#define declare_integrable(name, enc, etyp, igname, arity, lcode) 
-#elif defined(VM_GEN_INTGTABLE)
-#define declare_instruction(name, enc, etyp, igname, arity, lcode) \
-  declare_intgtable_entry(enc, igname, arity, lcode)
-#define declare_integrable(name, enc, etyp, igname, arity, lcode) \
-  declare_intgtable_entry(enc, igname, arity, lcode)
-#else /* regular include */
-#define declare_instruction(name, enc, etyp, igname, arity, lcode) \
-  extern obj glue(cx_ins_2D, name); 
-#define declare_integrable(name, enc, etyp, igname, arity, lcode) 
+  extern obj glue(cx_ins_2D, name);
+#define declare_integrable(name, enc, etyp, igname, arity, lcode)
 extern obj vmcases[]; /* vm host */
 #endif
 

--- a/i.h
+++ b/i.h
@@ -654,7 +654,7 @@ declare_instruction(hostfct,    "Zf",           0,  "%host-facet",              
 declare_instruction(libdir,     "Zd",           0,  "base-library-directory",   '0', AUTOGL)
 declare_instruction(hshim,      "Zi\0f",        0,  "immediate-hash",           'b', AUTOGL)
 
-/* serialization, deserialization, compilation-related instructions */             
+/* serialization, deserialization, compilation-related instructions */
 declare_instruction(igp,        "U0",           0,  "integrable?",              '1', AUTOGL)
 declare_instruction(itrs,       "U1",           0,  "initial-transformers",     '0', AUTOGL)
 declare_instruction(glos,       "U2",           0,  "global-store",             '0', AUTOGL)
@@ -665,6 +665,7 @@ declare_instruction(igty,       "U6",           0,  "integrable-type",          
 declare_instruction(iggl,       "U7",           0,  "integrable-global",        '1', AUTOGL)
 declare_instruction(igco,       "U8",           0,  "integrable-code",          '2', AUTOGL)
 declare_instruction(vmclo,      "U9",           1,  "closure",                  '#', INLINED)
+declare_instruction(vmcloco,    "Ug",           0,  "closure-code",             '2', AUTOGL)
 
 /* inlined integrables (no custom instructions) */               
 declare_integrable(NULL,        "q",            0,  "boolean=?",                'c', AUTOGL)

--- a/i.h
+++ b/i.h
@@ -653,6 +653,7 @@ declare_instruction(hostsig,    "Zs",           0,  "%host-sig",                
 declare_instruction(hostfct,    "Zf",           0,  "%host-facet",              '1', AUTOGL)
 declare_instruction(libdir,     "Zd",           0,  "base-library-directory",   '0', AUTOGL)
 declare_instruction(hshim,      "Zi\0f",        0,  "immediate-hash",           'b', AUTOGL)
+declare_instruction(addr,       "Za",           0,  "address-of",               '1', AUTOGL)
 
 /* serialization, deserialization, compilation-related instructions */
 declare_instruction(igp,        "U0",           0,  "integrable?",              '1', AUTOGL)

--- a/lib/skint/disassemble.sld
+++ b/lib/skint/disassemble.sld
@@ -1,0 +1,34 @@
+(define-library (skint disassemble)
+  (import (scheme base)
+          (scheme write)
+          (only (skint hidden) %closure-code-ref %procedure->inst-name))
+
+  (export disassemble)
+
+  (begin
+    (define (print-disassembled vec)
+      (vector-for-each
+       (lambda (elem)
+         (cond
+          ((vector? elem)
+           (display "{\n")
+           (print-disassembled elem)
+           (display "\n}\n"))
+          (else
+           (if (%procedure->inst-name elem)
+               (display (%procedure->inst-name elem))
+               (write elem))
+           (newline))))
+       vec))
+    (define (disassemble proc)
+      (let collect-code ((idx 0)
+                         (acc '()))
+        (let ((code (%closure-code-ref proc idx)))
+          (if code
+              (collect-code (+ idx 1)
+                            (cons code acc))
+              (begin
+                (print-disassembled
+                 (list->vector
+                  (reverse acc)))
+                (values))))))))


### PR DESCRIPTION
@dermagen this is a small and utterly incorrect disassembler I hacked this night. The output right now looks like this:
```
(disassemble vector-for-each)

{
shrarg
2
sref0
nullp
brnot
20
sref2
vlen
shi0
push
push
sbox
0
pushsref0
pushsref5
pushsref7
pushsref5
dclose
4
{
atest1
pushdref0
sref1
ige
brnot
1
sreturn1
save
6
pushsref2
dref1
vget
push
dref2
call1
pushlit1
sref1
iadd
push
drefi3
scall11

}
sseti
0
srefi0
adrop
1
scall41
save
10
pushsref2
sref5
cons
push
gref
#&#<procedure @0x7fcf61fe17a0>
push
gref
#&#<procedure @0x7fcf61fdf620>
call2
push
sref2
cons
push
gref
#&#<procedure @0x7fcf61fdf088>
push
gref
#&#<procedure @0x7fcf61fdf708>
scall32
#<procedure @0x559940a24720>

}
0
```

Which is already pretty useful and readable, but has some problems, like these boxes and broken disassembly for integrables:
```
{
shrarg
0
sref0
nullp
brnot
2
lit0
sreturn1
sref0
cdr
push
sref1
car
push
push
sbox
0
pushsref0
dclose
1
{
atest2
sref1
nullp
brnot
2
sref0
sreturn2
sref1
cdr
push
sref2
car
push
sref2
add
push
drefi0
scall22

}
sseti
0
srefi0
adrop
1
scall12
#<procedure @0x559940a24720>

}
0
```

@dermagen just tell me if it’s a good direction.